### PR TITLE
Add equivalent support for catkin tools (Issue #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ development.
 
 ## Getting Started
 
-The extension will automatically start when you open a catkin workspace, or a folder which is inside a catkin workspace.
+The extension will automatically start when you open a catkin workspace.
+The build system (e.g. catkin_make or catkin build) will automatically be confirmed from the hidden files associated with
+each system.
 The ROS distro will automatically be confirmed from the parent environment, or you will be prompted to select a ROS
 distro if this can't be done automatically.
 
@@ -18,15 +20,15 @@ To start ROS master, use the "ROS: Start Core" command. The "ROS master" indicat
 master is currently running, and you can click on this to view parameters etc. If you hit F5 you can create a debug
 configuration to run a `rosrun` or `roslaunch` command.
 
-The first time you open the workspace the extension will automatically create a `catkin_make` build task and update the
+The first time you open the workspace the extension will automatically create build and test tasks and update the
 C++ and Python paths. You can re-run this process later using the appropriate commands.
 
 ## Features
 
 * Automatic ROS environment configuration.
 * Allows starting, stopping and viewing the ROS master status.
-* Automatically discover `catkin_make` build tasks.
-* Create catkin packages.
+* Automatically discover `catkin_make` or `catkin build` build tasks.
+* Create catkin packages using `catkin_create_pkg` script or `catkin create pkg`.
 * Run `rosrun` or `roslaunch` (breakpoints currently not supported).
 * Syntax highlighting for `.msg`, `.urdf` and other ROS files.
 * Automatically add the ROS C++ include and Python import paths.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "workspaceContains:.catkin_workspace",
+    "workspaceContains:.catkin_tools"
   ],
   "main": "./out/src/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,26 @@
         "ros.distro": {
           "type": "string",
           "description": "ROS distro name to use (kinetic, jade, ...)"
+        },
+        "ros.hideBuildSpace": {
+          "type": "boolean",
+          "description": "Whether to hide the build directory from Explorer and Search",
+          "default": true
+        },
+        "ros.hideDevelSpace": {
+          "type": "boolean",
+          "description": "Whether to hide the devel directory from Explorer and Search",
+          "default": true
+        },
+        "ros.hideInstallSpace": {
+          "type": "boolean",
+          "description": "Whether to hide the install directory from Explorer and Search",
+          "default": true
+        },
+        "ros.hideLogSpace": {
+          "type": "boolean",
+          "description": "Whether to hide the log directory from Explorer and Search",
+          "default": true
         }
       }
     },

--- a/src/catkin-task-provider.ts
+++ b/src/catkin-task-provider.ts
@@ -6,17 +6,25 @@ import * as vscode from "vscode";
  */
 export default class CatkinTaskProvider implements vscode.TaskProvider {
   public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
-    const command = `catkin_make --directory "${extension.baseDir}"`;
+    let buildCommand: string;
+    let testCommand: string;
+    if (extension.buildSystem === "CatkinMake") {
+      buildCommand = `catkin_make --directory "${extension.baseDir}"`;
+      testCommand = `${buildCommand} run_tests`;
+    } else {
+      buildCommand = `catkin build --workspace "${extension.baseDir}"`;
+      testCommand = `${buildCommand} --catkin-make-args run_tests`;
+    }
 
     const make = new vscode.Task({ type: "catkin" }, "make", "catkin");
-    make.execution = new vscode.ShellExecution(command, {
+    make.execution = new vscode.ShellExecution(buildCommand, {
       env: extension.env
     });
     make.group = vscode.TaskGroup.Build;
     make.problemMatchers = ["$catkin-gcc"];
 
     const test = new vscode.Task({ type: "catkin", target: "run_tests" }, "run_tests", "catkin");
-    test.execution = new vscode.ShellExecution(`${command} run_tests`, {
+    test.execution = new vscode.ShellExecution(testCommand, {
       env: extension.env
     });
     test.group = vscode.TaskGroup.Test;

--- a/src/catkin.ts
+++ b/src/catkin.ts
@@ -24,10 +24,16 @@ export async function createPackage(uri?: vscode.Uri) {
     return;
   }
 
-  const cwd = typeof uri !== "undefined" ? uri.fsPath : vscode.workspace.rootPath;
+  const cwd = typeof uri !== "undefined" ? uri.fsPath : `${extension.baseDir}/src`;
   const opts = { cwd, env: extension.env };
 
-  cp.exec(`catkin_create_pkg ${name} ${dependencies}`, opts, (err, stdout, stderr) => {
+  let createPkgCommand: string;
+  if (extension.buildSystem === "CatkinMake") {
+    createPkgCommand = `catkin_create_pkg ${name} ${dependencies}`;
+  } else {
+    createPkgCommand = `catkin create pkg --catkin-deps ${dependencies} -- ${name}`;
+  }
+  cp.exec(createPkgCommand, opts, (err, stdout, stderr) => {
     if (!err) {
       vscode.workspace.openTextDocument(`${cwd}/${name}/package.xml`).then(vscode.window.showTextDocument);
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,11 @@ let context: vscode.ExtensionContext;
 export let baseDir: string;
 
 /**
+ * The build system in use.
+ */
+export let buildSystem: string;
+
+/**
  * The sourced ROS environment.
  */
 export let env: any;
@@ -31,16 +36,13 @@ export let onDidChangeEnv = onEnvChanged.event;
 /**
  * Subscriptions to dispose when the environment is changed.
  */
-let subscriptions = <vscode.Disposable[]> [];
+let subscriptions = <vscode.Disposable[]>[];
 
 export async function activate(ctx: vscode.ExtensionContext) {
   // Activate if we're in a catkin workspace.
   context = ctx;
-  baseDir = await utils.findCatkinWorkspace(vscode.workspace.rootPath);
-
-  if (!baseDir) {
-    return;
-  }
+  baseDir = vscode.workspace.rootPath;
+  buildSystem = await utils.determineBuildSystem(baseDir);
 
   // Activate components when the ROS env is changed.
   context.subscriptions.push(onDidChangeEnv(activateEnvironment));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 import * as extension from "./extension";
 import * as pfs from "./promise-fs";
 import * as cp from "child_process";
-import { dirname } from "path";
 import * as _ from "underscore";
 import * as vscode from "vscode";
 
@@ -13,15 +12,15 @@ export function getConfig(): vscode.WorkspaceConfiguration {
 }
 
 /**
- * Traverses up directories to find a catkin workspace.
+ * Determines build system in use by checking for unique auto-generated files.
  */
-export async function findCatkinWorkspace(dir: string): Promise<string> {
-  while (dir && dirname(dir) !== dir) {
-    if (await pfs.exists(`${dir}/.catkin_workspace`)) {
-      return dir;
+export async function determineBuildSystem(workspaceDir: string): Promise<string> {
+  if (workspaceDir) {
+    if (await pfs.exists(`${workspaceDir}/.catkin_workspace`)) {
+      return "CatkinMake";
+    } else if (await pfs.exists(`${workspaceDir}/.catkin_tools`)) {
+      return "CatkinTools";
     }
-
-    dir = dirname(dir);
   }
 }
 


### PR DESCRIPTION
Make the command ros.createCatkinPackage, as well as the build and test
tasks work in catkin tools-based workspaces.

The extension will only activate if it detects either of the
.catkin_workspace or .catkin_tools hidden files in the
`workspace.rootPath`. Users will still have to build their workspace once
before using the extension, and the extension does not provide a way to
change the build system while it is active.

Resolves: #4